### PR TITLE
Remove unused logfile serving

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -42,8 +42,6 @@ CodeChain Agent Hub will listen 3012 port to communicate with the Dashboard usin
 
 CodeChain Agent Hub will listen 4012 port to communicate with the Agent using JSON-RPC.
 
-CodeChain Agent Hub will listen 5012 port to serve CodeChain's log file using HTTP.
-
 Alerts
 -------
 

--- a/ui/src/components/NodeList/NodeDetailContainer/NodeDetail/NodeDetail.tsx
+++ b/ui/src/components/NodeList/NodeDetailContainer/NodeDetail/NodeDetail.tsx
@@ -106,11 +106,6 @@ const getCpuUsage = (cpuUsage: number[]) => {
 };
 
 export default class NodeDetail extends React.Component<Props, State> {
-  private logFileHost = `${
-    process.env.REACT_APP_LOG_SERVER_HOST
-      ? process.env.REACT_APP_LOG_SERVER_HOST
-      : "http://localhost:5012"
-  }`;
   public constructor(props: Props) {
     super(props);
     this.state = {
@@ -172,16 +167,6 @@ export default class NodeDetail extends React.Component<Props, State> {
               </div>
             </div>
           )}
-          <div className="text-right">
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              className="link-text"
-              href={`${this.logFileHost}/log/${nodeInfo.name}`}
-            >
-              Show logs
-            </a>
-          </div>
           <hr />
           <div className="data-row">
             <div>Version</div>


### PR DESCRIPTION
Currently, logfiles are only readable in each machine. The log file's
size is too big to handle in the web request. The static logfile
serving feature is unused now.