### PR TITLE
Ignore error from "logs" request

### DIFF
--- a/server/src/agent/agent.rs
+++ b/server/src/agent/agent.rs
@@ -456,7 +456,7 @@ impl Agent {
             );
         }
 
-        let logs = self.codechain_rpc.get_logs(info.status)?;
+        let logs = self.codechain_rpc.get_logs(info.status);
         self.db_service.write_logs(info.name, logs);
 
         let update_result = UpdateResult {

--- a/server/src/agent/codechain_rpc.rs
+++ b/server/src/agent/codechain_rpc.rs
@@ -65,13 +65,18 @@ impl CodeChainRPC {
         self.call_rpc(status, "net_recentNetworkUsage", Vec::new())
     }
 
-    pub fn get_logs(&self, status: NodeStatus) -> Result<Vec<StructuredLog>, String> {
+    pub fn get_logs(&self, status: NodeStatus) -> Vec<StructuredLog> {
         if status != NodeStatus::Run {
-            return Ok(Default::default())
+            return Vec::new()
         }
-        let response = self.sender.shell_get_codechain_log().map_err(|err| format!("{}", err))?;
-
-        Ok(response)
+        let response = self.sender.shell_get_codechain_log().map_err(|err| format!("{}", err));
+        match response {
+            Ok(logs) => logs,
+            Err(err) => {
+                cerror!("Fail to get logs {}", err);
+                Vec::new()
+            }
+        }
     }
 
     fn call_rpc<T>(&self, status: NodeStatus, method: &str, params: Vec<Value>) -> Result<T, String>


### PR DESCRIPTION
The 'logs' request is expensive. Do not close the connection even
though the response is not received.