### PR TITLE
Do not send disk usage alarm when the data is null value

### DIFF
--- a/server/src/agent/agent.rs
+++ b/server/src/agent/agent.rs
@@ -344,7 +344,7 @@ impl Agent {
 
                 const ONE_GB: i64 = 1_000_000_000;
                 if !disk_usage_alert_sent {
-                    if disk_usage.available < ONE_GB {
+                    if disk_usage.total != 0 && disk_usage.available < ONE_GB {
                         self.noti.warn(
                             &network_id,
                             &format!("{} has only {} MB free space.", node_name, disk_usage.available / 1_000_000),


### PR DESCRIPTION
When the Agent client can't get disk information, it fills all data to zero.
The Agent server should ignore the null value data.